### PR TITLE
feedbacks resolved

### DIFF
--- a/src/resources/addresses/AddressForm.tsx
+++ b/src/resources/addresses/AddressForm.tsx
@@ -23,7 +23,7 @@ export default function AddressForm(props: Props): React.ReactElement {
       resource={R_ADDRESSES}
       toolbar={showForm ? false : undefined}>
       <TextInput sx={sx} disabled={show} multiline source='fullAddress' />
-      <BooleanInput disabled={show} source='active' />
+      <BooleanInput disabled={show} defaultValue={true} source='active' />
       {showForm && (
         <DateInput sx={sx} disabled={show} multiline source='createdAt' />
       )}

--- a/src/resources/destruction/DestructionForm.tsx
+++ b/src/resources/destruction/DestructionForm.tsx
@@ -23,7 +23,7 @@ interface Props {
 }
 
 const schema = yup.object({
-  remarks: yup.string().required()
+  remarks: yup.string()
 })
 
 interface DestructionFormToolbarProps {

--- a/src/resources/destruction/DestructionShow.tsx
+++ b/src/resources/destruction/DestructionShow.tsx
@@ -96,7 +96,7 @@ const Footer = (props: FooterProps): React.ReactElement => {
       <FlexBox justifyContent='end' padding={2}>
         <Button
           variant='outlined'
-          label='Report'
+          label='Destruction Cerificatate'
           onClick={() => {
             handleOpen(true)
           }}

--- a/src/resources/dispatch/DispatchShow.tsx
+++ b/src/resources/dispatch/DispatchShow.tsx
@@ -129,7 +129,7 @@ const Footer = (props: FooterProps): React.ReactElement => {
           <>
             <Button
               variant='outlined'
-              label='Print Note'
+              label='Print Receipt'
               onClick={() => {
                 handleOpen('dispatch')
               }}

--- a/src/resources/platforms/index.tsx
+++ b/src/resources/platforms/index.tsx
@@ -25,7 +25,7 @@ const PlatformForm = (): React.ReactElement => {
       resolver={yupResolver(schema)}
       toolbar={<EditToolBar />}>
       <TextInput source='name' variant='outlined' sx={{ width: '100%' }} />
-      <BooleanInput source='active' />
+      <BooleanInput defaultValue={true} source='active' />
     </SimpleForm>
   )
 }

--- a/src/resources/reference-data/ReferenceDataForm.tsx
+++ b/src/resources/reference-data/ReferenceDataForm.tsx
@@ -26,7 +26,7 @@ export default function ReferenceDataForm(
       resolver={yupResolver(schema)}>
       <TextInput source='name' variant='outlined' sx={{ width: '100%' }} />
       {isEdit !== undefined && name !== undefined && !isNotActive(name) ? (
-        <BooleanInput source='active' />
+        <BooleanInput defaultValue={true} source='active' />
       ) : (
         ''
       )}

--- a/src/resources/reference-data/ReferenceDataForm.tsx
+++ b/src/resources/reference-data/ReferenceDataForm.tsx
@@ -13,7 +13,8 @@ export default function ReferenceDataForm(
 ): React.ReactElement {
   const { isEdit, name } = props
   const defaultValues = {
-    name: ''
+    name: '',
+    active: true
   }
 
   const isNotActive = (name: string): boolean => name === 'audit'

--- a/src/resources/users/UserForm.tsx
+++ b/src/resources/users/UserForm.tsx
@@ -69,7 +69,7 @@ export default function UserForm({ isEdit }: FormProps): React.ReactElement {
       </FlexBox>
       <FlexBox>
         <BooleanInput source='adminRights' />
-        <BooleanInput source='active' />
+        <BooleanInput defaultValue={true} source='active' />
       </FlexBox>
     </SimpleForm>
   )

--- a/src/resources/vault-locations/VaultLocationForm.tsx
+++ b/src/resources/vault-locations/VaultLocationForm.tsx
@@ -20,7 +20,7 @@ export default function VaultLocationForm(): React.ReactElement {
       defaultValues={defaultValues}
       resolver={yupResolver(schema)}>
       <TextInput source='name' variant='outlined' sx={{ width: '100%' }} />
-      <BooleanInput source='active' />
+      <BooleanInput defaultValue={true} source='active' />
     </SimpleForm>
   )
 }


### PR DESCRIPTION
Feedbacks:
- When creating a destruction the “remarks” field is mandatory, is there a reason why its mandatory? The same field in Dispatch is not mandatory. Could this field be set to non mandatory?
- Could the “report” button in destructions be renamed to Destruction Cerificatate?
- Could the “print note” button in dispatches be renamed to Print Receipt
- When setting up addresses can they automatically be set to active, rather than having to active them after the event?