### PR TITLE
Hotfix reference item naming

### DIFF
--- a/src/components/ReferenceDataList.tsx
+++ b/src/components/ReferenceDataList.tsx
@@ -24,7 +24,7 @@ export default function ReferenceDataList({
 }: PropType): React.ReactElement {
   const cName: string = name
   const [open, setOpen] = useState<boolean>()
-  const [record, setRecord] = useState<ActiveReferenceItem>()
+  const [record, setRecord] = useState<IntegerReferenceItem>()
 
   const { hasAccess } = useCanAccess()
 
@@ -67,7 +67,7 @@ export default function ReferenceDataList({
         {notShowActive(name) ? '' : <BooleanField source='active' />}
         <FunctionField
           label='History'
-          render={(record: ActiveReferenceItem) => {
+          render={(record: IntegerReferenceItem) => {
             return (
               <IconButton
                 onClick={(e) => {

--- a/src/components/VaultLocationReport.tsx
+++ b/src/components/VaultLocationReport.tsx
@@ -22,7 +22,7 @@ import SourceField from './SourceField'
 import { DateTime } from 'luxon'
 import ReportSignature from './ReportSignature'
 
-type ReferenceItemById = Record<number, ActiveReferenceItem>
+type ReferenceItemById = Record<number, IntegerReferenceItem>
 interface Result {
   name: string
   count: number
@@ -44,7 +44,7 @@ function ProtectiveMarking(): React.ReactElement {
       }
     })
     const { data: protectiveMarkings } =
-      await dataProvider.getMany<ActiveReferenceItem>(
+      await dataProvider.getMany<IntegerReferenceItem>(
         constants.R_PROTECTIVE_MARKING,
         {
           ids: Object.keys(items)
@@ -105,7 +105,7 @@ export default function VaultLocationReport(props: Props): ReactElement {
   const dataProvider = useDataProvider()
   useEffect(() => {
     dataProvider
-      .getList<ActiveReferenceItem>(constants.R_VAULT_LOCATION, {
+      .getList<IntegerReferenceItem>(constants.R_VAULT_LOCATION, {
         sort: { field: 'id', order: 'ASC' },
         pagination: { page: 1, perPage: 1000 },
         filter: { id: selectedIds }

--- a/src/providers/dataProvider/tests/common.ts
+++ b/src/providers/dataProvider/tests/common.ts
@@ -11,15 +11,15 @@ const TEST_STORAGE_KEY = 'rco-test'
 interface CommonReturnType {
   checkEmptyAuditList: (provider: DataProvider) => Promise<void>
   checkAuditListForFirstEntry: (
-    createdResource: ActiveReferenceItem
+    createdResource: IntegerReferenceItem
   ) => Promise<void>
   checkAuditListForSecondEntry: (
-    createdResource: ActiveReferenceItem
+    createdResource: IntegerReferenceItem
   ) => Promise<void>
   createResource: (
     dummyDataGenerate: typeof generateActiveReferenceItemForTesting,
     resource: ResourceTypes
-  ) => Promise<ActiveReferenceItem>
+  ) => Promise<IntegerReferenceItem>
   checkListBeforeCreate: () => Promise<void>
   checkListAfterCreate: () => Promise<void>
 }
@@ -39,7 +39,7 @@ const common = (
       expect(auditList.total).toBe(0)
     },
     checkAuditListForFirstEntry: async (
-      createdResource: ActiveReferenceItem
+      createdResource: IntegerReferenceItem
     ): Promise<void> => {
       const auditList = await provider.getList<Audit>(R_AUDIT, {
         sort: { field: 'id', order: 'ASC' },
@@ -56,7 +56,7 @@ const common = (
     },
 
     checkAuditListForSecondEntry: async (
-      createdResource: ActiveReferenceItem
+      createdResource: IntegerReferenceItem
     ): Promise<void> => {
       const auditList = await provider.getList<Audit>(R_AUDIT, {
         sort: { field: 'id', order: 'ASC' },
@@ -74,9 +74,9 @@ const common = (
     createResource: async (
       dummyDataGenerate: typeof generateActiveReferenceItemForTesting,
       resource: ResourceTypes
-    ): Promise<ActiveReferenceItem> => {
+    ): Promise<IntegerReferenceItem> => {
       const createdResource = (
-        await provider.create<ActiveReferenceItem>(resource, {
+        await provider.create<IntegerReferenceItem>(resource, {
           data: dummyDataGenerate(`Dummy-${(resource as string).toUpperCase()}`)
         })
       ).data
@@ -88,7 +88,7 @@ const common = (
     },
 
     checkListBeforeCreate: async (): Promise<void> => {
-      const listBeforeCreate = await provider.getList<ActiveReferenceItem>(
+      const listBeforeCreate = await provider.getList<IntegerReferenceItem>(
         resource,
         {
           sort: { field: 'id', order: 'ASC' },
@@ -100,7 +100,7 @@ const common = (
     },
 
     checkListAfterCreate: async (): Promise<void> => {
-      const listAfterCreate = await provider.getList<ActiveReferenceItem>(
+      const listAfterCreate = await provider.getList<IntegerReferenceItem>(
         resource,
         {
           sort: { field: 'id', order: 'ASC' },

--- a/src/providers/dataProvider/tests/department.test.ts
+++ b/src/providers/dataProvider/tests/department.test.ts
@@ -24,7 +24,7 @@ describe('CRUD operation on department', () => {
     createResource: (
       dummyDataGenerate: typeof generateActiveReferenceItemForTesting,
       resource: ResourceTypes
-    ) => Promise<ActiveReferenceItem>
+    ) => Promise<IntegerReferenceItem>
 
   beforeAll(async () => {
     const provider = await localForageDataProvider({
@@ -57,7 +57,7 @@ describe('CRUD operation on department', () => {
       R_DEPARTMENT
     )
 
-    await provider.update<ActiveReferenceItem>(R_DEPARTMENT, {
+    await provider.update<IntegerReferenceItem>(R_DEPARTMENT, {
       id: createdDepartment.id,
       previousData: createdDepartment,
       data: {
@@ -68,7 +68,7 @@ describe('CRUD operation on department', () => {
     })
 
     const fetchedDepartment = (
-      await provider.getOne<ActiveReferenceItem>(R_DEPARTMENT, {
+      await provider.getOne<IntegerReferenceItem>(R_DEPARTMENT, {
         id: createdDepartment.id
       })
     ).data

--- a/src/providers/dataProvider/tests/dummy-data.ts
+++ b/src/providers/dataProvider/tests/dummy-data.ts
@@ -140,7 +140,7 @@ export const generateVaultLocationForTesting = ({
   id,
   active,
   name
-}: VaultLocationProps = {}): Omit<ActiveReferenceItem, 'id'> => ({
+}: VaultLocationProps = {}): Omit<IntegerReferenceItem, 'id'> => ({
   ...(id !== undefined ? { id } : null),
   active: active ?? true,
   name: name ?? 'Dummy-Vault-Location-1'
@@ -154,7 +154,7 @@ interface ActiveReferenceItemProps {
 export const generateActiveReferenceItemForTesting = (
   name: string,
   { id, active }: ActiveReferenceItemProps = {}
-): Omit<ActiveReferenceItem, 'id'> => ({
+): Omit<IntegerReferenceItem, 'id'> => ({
   ...(id !== undefined ? { id } : null),
   active: active ?? true,
   name

--- a/src/providers/dataProvider/tests/media-type.test.ts
+++ b/src/providers/dataProvider/tests/media-type.test.ts
@@ -23,7 +23,7 @@ describe('CRUD operation on Media Type Resource', () => {
     createResource: (
       dummyDataGenerate: typeof generateActiveReferenceItemForTesting,
       resource: ResourceTypes
-    ) => Promise<ActiveReferenceItem>
+    ) => Promise<IntegerReferenceItem>
 
   beforeAll(async () => {
     const provider = await localForageDataProvider({
@@ -55,7 +55,7 @@ describe('CRUD operation on Media Type Resource', () => {
       R_MEDIA_TYPE
     )
 
-    await provider.update<ActiveReferenceItem>(R_MEDIA_TYPE, {
+    await provider.update<IntegerReferenceItem>(R_MEDIA_TYPE, {
       id: createdMediaType.id,
       previousData: createdMediaType,
       data: {
@@ -66,7 +66,7 @@ describe('CRUD operation on Media Type Resource', () => {
     })
 
     const fetchedMediaType = (
-      await provider.getOne<ActiveReferenceItem>(R_MEDIA_TYPE, {
+      await provider.getOne<IntegerReferenceItem>(R_MEDIA_TYPE, {
         id: createdMediaType.id
       })
     ).data

--- a/src/providers/dataProvider/tests/organisation.test.ts
+++ b/src/providers/dataProvider/tests/organisation.test.ts
@@ -23,7 +23,7 @@ describe('CRUD operation on Organisation Resource', () => {
     createResource: (
       dummyDataGenerate: typeof generateActiveReferenceItemForTesting,
       resource: ResourceTypes
-    ) => Promise<ActiveReferenceItem>
+    ) => Promise<IntegerReferenceItem>
 
   beforeAll(async () => {
     const provider = await localForageDataProvider({
@@ -55,7 +55,7 @@ describe('CRUD operation on Organisation Resource', () => {
       R_ORGANISATION
     )
 
-    await provider.update<ActiveReferenceItem>(R_ORGANISATION, {
+    await provider.update<IntegerReferenceItem>(R_ORGANISATION, {
       id: createdOrganisation.id,
       previousData: createdOrganisation,
       data: {
@@ -66,7 +66,7 @@ describe('CRUD operation on Organisation Resource', () => {
     })
 
     const fetchedOrganisation = (
-      await provider.getOne<ActiveReferenceItem>(R_ORGANISATION, {
+      await provider.getOne<IntegerReferenceItem>(R_ORGANISATION, {
         id: createdOrganisation.id
       })
     ).data

--- a/src/providers/dataProvider/tests/protective-marking.test.ts
+++ b/src/providers/dataProvider/tests/protective-marking.test.ts
@@ -23,7 +23,7 @@ describe('CRUD operation on Media Type Resource', () => {
     createResource: (
       dummyDataGenerate: typeof generateActiveReferenceItemForTesting,
       resource: ResourceTypes
-    ) => Promise<ActiveReferenceItem>
+    ) => Promise<IntegerReferenceItem>
 
   beforeAll(async () => {
     const provider = await localForageDataProvider({
@@ -58,7 +58,7 @@ describe('CRUD operation on Media Type Resource', () => {
       R_PROTECTIVE_MARKING
     )
 
-    await provider.update<ActiveReferenceItem>(R_PROTECTIVE_MARKING, {
+    await provider.update<IntegerReferenceItem>(R_PROTECTIVE_MARKING, {
       id: createdProtectiveMarking.id,
       previousData: createdProtectiveMarking,
       data: {
@@ -69,7 +69,7 @@ describe('CRUD operation on Media Type Resource', () => {
     })
 
     const fetchedProtectiveMarking = (
-      await provider.getOne<ActiveReferenceItem>(R_PROTECTIVE_MARKING, {
+      await provider.getOne<IntegerReferenceItem>(R_PROTECTIVE_MARKING, {
         id: createdProtectiveMarking.id
       })
     ).data

--- a/src/providers/dataProvider/tests/reference-item.ts
+++ b/src/providers/dataProvider/tests/reference-item.ts
@@ -20,7 +20,7 @@ const referenceItemTests = (
     async () => {
       await checkEmptyAuditList(provider)
       const createdActiveReferenceItem = (
-        await provider.create<ActiveReferenceItem>(resource, {
+        await provider.create<IntegerReferenceItem>(resource, {
           data: dummyDataGenerate(`Dummy-${(resource as string).toUpperCase()}`)
         })
       ).data
@@ -30,7 +30,7 @@ const referenceItemTests = (
     async () => {
       await checkEmptyAuditList(provider)
       const createdActiveReferenceItem = (
-        await provider.create<ActiveReferenceItem>(resource, {
+        await provider.create<IntegerReferenceItem>(resource, {
           data: generateActiveReferenceItemForTesting(
             `Dummy-${(resource as string).toUpperCase()}`
           )
@@ -38,7 +38,7 @@ const referenceItemTests = (
       ).data
       await checkAuditListForFirstEntry(createdActiveReferenceItem)
 
-      await provider.update<ActiveReferenceItem>(resource, {
+      await provider.update<IntegerReferenceItem>(resource, {
         id: createdActiveReferenceItem.id,
         previousData: createdActiveReferenceItem,
         data: {

--- a/src/providers/dataProvider/tests/vaultLocation.test.ts
+++ b/src/providers/dataProvider/tests/vaultLocation.test.ts
@@ -53,7 +53,7 @@ describe('CRUD operations vault location', () => {
 
   it('should create vault location', async () => {
     const vaultLocationListBeforeCreate =
-      await provider.getList<ActiveReferenceItem>(R_VAULT_LOCATION, {
+      await provider.getList<IntegerReferenceItem>(R_VAULT_LOCATION, {
         sort: { field: 'id', order: 'ASC' },
         pagination: { page: 1, perPage: 1000 },
         filter: {}
@@ -62,7 +62,7 @@ describe('CRUD operations vault location', () => {
     expect(vaultLocationListBeforeCreate.total).toBe(0)
 
     const createdVault = (
-      await provider.create<ActiveReferenceItem>(R_VAULT_LOCATION, {
+      await provider.create<IntegerReferenceItem>(R_VAULT_LOCATION, {
         data: generateVaultLocationForTesting()
       })
     ).data
@@ -73,7 +73,7 @@ describe('CRUD operations vault location', () => {
 
   it('should update vault location', async () => {
     const createdVault = (
-      await provider.create<ActiveReferenceItem>(R_VAULT_LOCATION, {
+      await provider.create<IntegerReferenceItem>(R_VAULT_LOCATION, {
         data: generateVaultLocationForTesting()
       })
     ).data
@@ -81,14 +81,14 @@ describe('CRUD operations vault location', () => {
     expect(createdVault).not.toBeUndefined()
     expect(createdVault.id).toBeDefined()
 
-    await provider.update<ActiveReferenceItem>(R_VAULT_LOCATION, {
+    await provider.update<IntegerReferenceItem>(R_VAULT_LOCATION, {
       id: createdVault.id,
       previousData: createdVault,
       data: { id: createdVault.id, name: 'dummy-vault-1', active: false }
     })
 
     const fetchedVault = (
-      await provider.getOne<ActiveReferenceItem>(R_VAULT_LOCATION, {
+      await provider.getOne<IntegerReferenceItem>(R_VAULT_LOCATION, {
         id: createdVault.id
       })
     ).data

--- a/src/resources/batches/BatchForm.tsx
+++ b/src/resources/batches/BatchForm.tsx
@@ -55,7 +55,7 @@ interface Props {
   active?: boolean
 }
 
-export const ConditionalReferenceInput = <T extends ActiveReferenceItem>(
+export const ConditionalReferenceInput = <T extends IntegerReferenceItem>(
   props: Props
 ): React.ReactElement | null => {
   const { source, reference, inputProps = {}, active } = props

--- a/src/resources/items/ItemForm/ChangeLocation.tsx
+++ b/src/resources/items/ItemForm/ChangeLocation.tsx
@@ -50,7 +50,7 @@ export default function ChangeLocation(
 
   const vaultLocationValue: number | string = watch('vaultLocation')
 
-  const [vaultLocation, setVaultLocation] = useState<ActiveReferenceItem[]>([])
+  const [vaultLocation, setVaultLocation] = useState<IntegerReferenceItem[]>([])
   const dataProvider = useDataProvider()
 
   async function onSubmit(values: FormState): Promise<void> {
@@ -68,7 +68,7 @@ export default function ChangeLocation(
 
   useEffect(() => {
     dataProvider
-      .getList<ActiveReferenceItem>(constants.R_VAULT_LOCATION, {
+      .getList<IntegerReferenceItem>(constants.R_VAULT_LOCATION, {
         sort: { field: 'id', order: 'ASC' },
         pagination: { page: 1, perPage: 1000 },
         filter: {}

--- a/src/resources/platforms/PlatformList.tsx
+++ b/src/resources/platforms/PlatformList.tsx
@@ -26,7 +26,7 @@ export default function PlatformList(props: Props): React.ReactElement {
   const basePath: string = `/${cName}`
   const { hasAccess } = useCanAccess()
   const [open, setOpen] = useState<boolean>()
-  const [record, setRecord] = useState<ActiveReferenceItem>()
+  const [record, setRecord] = useState<IntegerReferenceItem>()
 
   const filter = useMemo(
     () =>
@@ -80,7 +80,7 @@ export default function PlatformList(props: Props): React.ReactElement {
         <BooleanField source='active' label='Active Platform' />
         <FunctionField
           label='History'
-          render={(record: ActiveReferenceItem) => {
+          render={(record: IntegerReferenceItem) => {
             return (
               <IconButton
                 onClick={(e) => {

--- a/src/resources/vault-locations/VaultLocationList.tsx
+++ b/src/resources/vault-locations/VaultLocationList.tsx
@@ -11,7 +11,7 @@ import DatagridConfigurableWithShow from '../../components/DatagridConfigurableW
 export default function VaultLocationList(): React.ReactElement {
   const [open, setOpen] = useState<boolean>()
   const [openMusterList, setOpenMusterList] = useState(false)
-  const [record, setRecord] = useState<ActiveReferenceItem>()
+  const [record, setRecord] = useState<IntegerReferenceItem>()
 
   const filter = useMemo(
     () =>
@@ -54,7 +54,7 @@ export default function VaultLocationList(): React.ReactElement {
         <BooleanField source='active' label='Active Vault Location' />
         <FunctionField
           label='History'
-          render={(record: ActiveReferenceItem) => {
+          render={(record: IntegerReferenceItem) => {
             return (
               <IconButton
                 onClick={(e) => {

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -57,17 +57,18 @@ interface RCOResource {
  * interface becomes more complex, introduce a type-specific interface
  */
 interface ActiveItem {
+  // human-readable name for this entity
   name: string
+  // when false, the item should not be included in drop-downs
+  // for `create` forms, though it should for `edit` forms
   active: boolean
 }
 
-interface ActiveReferenceItem extends ActiveItem {
-  // when false, the item should not be included in drop-downs
-  // for `create` forms, though it should for `edit` forms
+interface IntegerReferenceItem extends ActiveItem {
   id: number
 }
 
-interface ReferenceItem extends ActiveItem {
+interface StringReferenceItem extends ActiveItem {
   id: string
 }
 
@@ -123,13 +124,13 @@ interface Project extends ResourceWithCreation {
   endDate: string
 }
 
-type Department = ReferenceItem
-type Organisation = ReferenceItem
-type ProtectiveMarking = ActiveReferenceItem
-type CatCode = ReferenceItem
-type CatHandle = ReferenceItem
-type CatCave = ReferenceItem
-type VaultLocation = ActiveReferenceItem
+type Department = StringReferenceItem
+type Organisation = StringReferenceItem
+type ProtectiveMarking = IntegerReferenceItem
+type CatCode = StringReferenceItem
+type CatHandle = StringReferenceItem
+type CatCave = StringReferenceItem
+type VaultLocation = IntegerReferenceItem
 
 interface ItemCode {
   id: number
@@ -215,7 +216,7 @@ interface RCOStore {
   organisation: Organisation[]
   department: Department[]
   vaultLocation: VaultLocation[]
-  mediaType: ActiveReferenceItem[]
+  mediaType: IntegerReferenceItem[]
   protectiveMarking: ProtectiveMarking[]
   catCode: CatCode[]
   catHandle: CatHandle[]
@@ -300,4 +301,4 @@ interface ConfigData extends RCOResource {
   cat_cave: string
 }
 
-type Vault = ActiveReferenceItem
+type Vault = IntegerReferenceItem

--- a/src/utils/init-data.ts
+++ b/src/utils/init-data.ts
@@ -152,7 +152,7 @@ const loadDefaultData = async (
 
   const vaultLocation = getActiveReferenceData<IntegerReferenceItem>({
     nameVal: 'Vault Location',
-    length: isHigh === true ? 100 : undefined,
+    length: isHigh === true ? 200 : 50,
     alternateInactive: true,
     isHigh
   })

--- a/src/utils/init-data.ts
+++ b/src/utils/init-data.ts
@@ -140,30 +140,30 @@ const loadDefaultData = async (
   const project = generateProject(isHigh === true ? 60 : 10, user)
   const vault = generateVault()
 
-  const organisation = getActiveReferenceData<ReferenceItem>({
+  const organisation = getActiveReferenceData<StringReferenceItem>({
     nameVal: 'Organisation',
     resource: constants.R_ORGANISATION
   })
 
-  const department = getActiveReferenceData<ReferenceItem>({
+  const department = getActiveReferenceData<StringReferenceItem>({
     nameVal: 'Department',
     resource: constants.R_DEPARTMENT
   })
 
-  const vaultLocation = getActiveReferenceData<ActiveReferenceItem>({
+  const vaultLocation = getActiveReferenceData<IntegerReferenceItem>({
     nameVal: 'Vault Location',
     length: isHigh === true ? 100 : undefined,
     isHigh,
     inActivePercentage: 5
   })
 
-  const mediaType = getActiveReferenceData<ActiveReferenceItem>({
+  const mediaType = getActiveReferenceData<IntegerReferenceItem>({
     nameVal: 'Media',
     alternateInactive: true,
     length: 30
   })
 
-  const protectiveMarking = getActiveReferenceData<ActiveReferenceItem>({
+  const protectiveMarking = getActiveReferenceData<IntegerReferenceItem>({
     nameVal: 'Protective Marking',
     alternateInactive: true
   })
@@ -174,17 +174,17 @@ const loadDefaultData = async (
     length: 8
   }
 
-  const catCode = getActiveReferenceData<ReferenceItem>({
+  const catCode = getActiveReferenceData<StringReferenceItem>({
     ...protectionFieldParams,
     nameVal: 'Cat Code',
     resource: constants.R_CAT_CODE
   })
-  const catHandle = getActiveReferenceData<ReferenceItem>({
+  const catHandle = getActiveReferenceData<StringReferenceItem>({
     ...protectionFieldParams,
     nameVal: 'Cat Handle',
     resource: constants.R_CAT_HANDLE
   })
-  const catCave = getActiveReferenceData<ReferenceItem>({
+  const catCave = getActiveReferenceData<StringReferenceItem>({
     ...protectionFieldParams,
     nameVal: 'Cat Cave',
     resource: constants.R_CAT_CAVE

--- a/src/utils/init-data.ts
+++ b/src/utils/init-data.ts
@@ -153,8 +153,8 @@ const loadDefaultData = async (
   const vaultLocation = getActiveReferenceData<IntegerReferenceItem>({
     nameVal: 'Vault Location',
     length: isHigh === true ? 100 : undefined,
-    isHigh,
-    inActivePercentage: 5
+    alternateInactive: true,
+    isHigh
   })
 
   const mediaType = getActiveReferenceData<IntegerReferenceItem>({


### PR DESCRIPTION
Some ActiveItems have an integer id, and some have a string id.

Make the type naming consistent/clear

Also, generate more vault locations