### PR TITLE
destroy item bug fixed

### DIFF
--- a/src/resources/items/DestroyItems.tsx
+++ b/src/resources/items/DestroyItems.tsx
@@ -49,7 +49,7 @@ export default function DestroyItems(props: Props): React.ReactElement {
     setLoading(true)
     dataProvider
       .getList<Destruction>(constants.R_DESTRUCTION, {
-        filter: { finalisedAt: undefined },
+        filter: { finalisedAt: null },
         sort: { field: 'id', order: 'ASC' },
         pagination: {
           page: 1,


### PR DESCRIPTION
fixes #650 

Will only work for `SQLite` as `SQLite` uses `null` whereas `mock` server uses `undefined`