### PR TITLE
bug fixed on destruction list and conditional Date field

### DIFF
--- a/src/resources/destruction/DestructionList.tsx
+++ b/src/resources/destruction/DestructionList.tsx
@@ -1,10 +1,4 @@
-import {
-  Datagrid,
-  DateField,
-  FunctionField,
-  List,
-  TextField
-} from 'react-admin'
+import { Datagrid, FunctionField, List, TextField } from 'react-admin'
 import SourceField from '../../components/SourceField'
 import * as constants from '../../constants'
 import ResourceHistoryModal from '../../components/ResourceHistory'
@@ -54,7 +48,6 @@ export default function DestructionList(): React.ReactElement {
           source='createdBy'
           reference={constants.R_USERS}
         />
-        <DateField<Destruction> source='finalisedAt' />
         <SourceField<Destruction>
           source='finalisedBy'
           reference={constants.R_USERS}

--- a/src/resources/destruction/DestructionShow.tsx
+++ b/src/resources/destruction/DestructionShow.tsx
@@ -1,7 +1,6 @@
 import React, { useMemo, useState } from 'react'
 import {
   Button,
-  DateField,
   Show,
   SimpleShowLayout,
   TextField,
@@ -31,6 +30,7 @@ import { AuditType } from '../../utils/activity-types'
 import ResourceHistoryModal from '../../components/ResourceHistory'
 import HistoryButton from '../../components/HistoryButton'
 import { type AuditData } from '../../utils/audit'
+import { ConditionalDateField } from '../dispatch/DispatchList'
 
 const Finalised = (): React.ReactElement => {
   const record = useRecordContext<Destruction>()
@@ -238,7 +238,11 @@ export default function DestructionShow(): React.ReactElement {
             actions={<ShowActions handleOpen={handleOpen} />}>
             <SimpleShowLayout>
               <TextField<Destruction> source='name' label='Reference' />
-              <DateField<Destruction> source='finalisedAt' />
+              <ConditionalDateField<Destruction>
+                label='Finalised at'
+                source='finalisedAt'
+                resource={constants.R_DESTRUCTION}
+              />
               <Finalised />
               <TextField<Destruction> source='remarks' />
             </SimpleShowLayout>

--- a/src/resources/dispatch/DispatchList.tsx
+++ b/src/resources/dispatch/DispatchList.tsx
@@ -116,7 +116,7 @@ export const ConditionalDateField = <T extends Dispatch | Destruction>({
 }: Props<T>): React.ReactElement => {
   const data = useRecordContext(resource)
 
-  return data[source as string] !== 'null' ? (
+  return data[source as string] !== 'null' && !!data[source as string] ? (
     <DateField source={source as string} label={label} />
   ) : (
     <></>


### PR DESCRIPTION
- In `DispatchList`, we were displaying `finalisedAt` two times with `ConditionalDateField` (this is correct) and `DateField` (this is wrong), the latter is removed in this PR. 
- Same was the case in `destructionShow`, we were using `DateField` instead of `ConditionalDateField`
- In `ConditionalDateField` we were comparing with `'null'` string and we should also be comparing with `null` and `undefined`, therefore, additional check in `ConditionalDateField`.
